### PR TITLE
Improve text format of the output messages

### DIFF
--- a/core/fluid2d.py
+++ b/core/fluid2d.py
@@ -143,8 +143,8 @@ class Fluid2d(object):
                 for trac in self.tracer_list:
                     print('    - %s' % trac)
             else:
-                print('-'*50)
                 print(' Output files:')
+                print('-'*50)
                 for f in outputfiles:
                     print('  - %s' % f)
                 print('-'*50)

--- a/core/fluid2d.py
+++ b/core/fluid2d.py
@@ -143,9 +143,10 @@ class Fluid2d(object):
                 for trac in self.tracer_list:
                     print('    - %s' % trac)
             else:
-                print('  - output files:')
+                print('-'*50)
+                print(' Output files:')
                 for f in outputfiles:
-                    print('    - %s' % f)
+                    print('  - %s' % f)
                 print('-'*50)
                 print(' You may recover all the experiment parameters by doing')
                 print(' ncdump -h %s' % self.output.hisfile)

--- a/core/gmg/hierarchy.py
+++ b/core/gmg/hierarchy.py
@@ -178,7 +178,7 @@ class Gmg(object):
             res0 = res
             nite += 1
             if (self.myrank == 0) and (param['verbose']):
-                print(' ite = %i / res = %g / conv = %g' % (nite, res, conv))
+                print(' ite = {} / res = {:.2e} / conv = {:8.4f}'.format(nite, res, conv))
 
             if (conv < 1):
                 nite_diverge += 1


### PR DESCRIPTION
Two improvements are implemented:
 - The residuals computed before the run are printed in a fixed format
   to avoid changing lengths of lines.
 - The names of the output files are printed in a format similar to the
   rest of the output.