### PR TITLE
Replace geometry "square" by "closed"

### DIFF
--- a/core/default.xml
+++ b/core/default.xml
@@ -104,7 +104,7 @@
     </name>
     <name value="geometry">
       <type>str</type>
-      <avail>disc,perio,square,ychannel,xchannel</avail>
+      <avail>disc,perio,closed,ychannel,xchannel</avail>
       <default>disc</default>
       <doc lang='en'>
         Domain shape. It offers a list of predefined masks. You may change the mask in your script. See for instance experiments/Vortex/vortex.py for an example.

--- a/core/defaults.json
+++ b/core/defaults.json
@@ -121,7 +121,7 @@
             "avail": [
                 "disc",
                 "perio",
-                "square",
+                "closed",
                 "ychannel",
                 "xchannel"
             ],

--- a/core/fluid2d.py
+++ b/core/fluid2d.py
@@ -54,7 +54,7 @@ class Fluid2d(object):
         grid.copy(self, self.list_grid)
 
         if param.modelname == 'euler':
-            if not(self.geometry in ['square', 'disc']):
+            if self.geometry not in ['closed', 'disc']:
                 self.enforce_momentum = False
             from euler import Euler
             self.model = Euler(param, grid)

--- a/core/grid.py
+++ b/core/grid.py
@@ -82,13 +82,13 @@ class Grid(Param):
         if self.geometry == 'perio':
             pass
 
-        if self.geometry in ['xperio', 'xchannel', 'closed', 'square', 'disc']:
+        if self.geometry in ['xperio', 'xchannel', 'closed', 'disc']:
             if self.j0 == npy-1:  # northern boundary
                 self.msk[-nh:, :] = 0
             if self.j0 == 0:  # southern boundary
                 self.msk[:nh, :] = 0
 
-        if self.geometry in ['yperio', 'ychannel', 'closed', 'square', 'disc']:
+        if self.geometry in ['yperio', 'ychannel', 'closed', 'disc']:
             if self.i0 == npx-1:  # east
                 self.msk[:, -nh:] = 0
             if self.i0 == 0:  # west
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     param.npy = 2
     param.nx = 10
     param.ny = 10
-    param.geometry = 'square'
+    param.geometry = 'closed'
     grid = Grid(param)
 
     print("myrank is :", param.myrank)

--- a/docs/experiment_template.py
+++ b/docs/experiment_template.py
@@ -26,11 +26,8 @@ param.Lx = 2.   # domain size in x [Lx can be dimensional if the user
 param.Ly = param.Lx/2 # domain size in y. The model imposes that dx=dy
                       # => Lx/nx = Ly/ny
 
-param.geometry='square' # square, disc, xchannel, ychannel,
-                        # perio. 'square' is a closed domain. For a
-                        # more complex domain, adjust the grid.msk
-                        # once grid is available
-
+param.geometry = 'closed'  # closed, disc, xchannel, ychannel, perio.
+# For a more complex domain, adjust the grid.msk once grid is available
 
 
 

--- a/experiments/GravityCurrent/gravitycurrent.py
+++ b/experiments/GravityCurrent/gravitycurrent.py
@@ -15,7 +15,7 @@ param.npx = 1
 param.npy = 1
 param.Lx = 2.
 param.Ly = 1.
-param.geometry = 'square'
+param.geometry = 'closed'
 
 # time
 param.tend = 5.

--- a/experiments/GyreCirculation/double_gyre.py
+++ b/experiments/GyreCirculation/double_gyre.py
@@ -13,7 +13,7 @@ param.ny = 64
 param.npy = 1
 param.Lx = 2.
 param.Ly = param.Lx/2
-param.geometry = 'square'
+param.geometry = 'closed'
 
 # time
 param.tend = 2000.


### PR DESCRIPTION
This is a proposed change to unify the use of the two geometries "square" and "closed" by completely removing "square". This means, the user has to use "closed" from now one. This was chosen because it is the more general term, since closed domains might not be squares. In many situations, they have rectangular shape with a 2x1-ratio.

Before this commit, the names "square" and "closed" were both used for
the same domain geometry.  However, square was used in many situations,
where the domain is not actually squared, but rectangular.  To avoid this
potential confusion, all remaining occurrences of "square" are replaced
by "closed".  Now, the geometry "square" cannot be used anymore.