### PR TITLE
Fix output when fluid2d runs on multiple cores

### DIFF
--- a/core/output.py
+++ b/core/output.py
@@ -26,7 +26,6 @@ class Output(Param):
         self.template = self.expdir+'/%s_his_%03i.nc'
         if self.nbproc > 1:
             self.hisfile = self.template % (self.expname, self.myrank)
-            self.hisfile_joined = '%s/%s_his.nc' % (self.expdir, self.expname)
         else:
             self.hisfile = '%s/%s_his.nc' % (self.expdir, self.expname)
 
@@ -43,7 +42,6 @@ class Output(Param):
             template = self.expdir+'/%s_flx_%03i.nc'
             if self.nbproc > 1:
                 self.flxfile = template % (self.expname, self.myrank)
-                self.flxfile_joined = '%s/%s_flx.nc' % (self.expdir, self.expname)
             else:
                 self.flxfile = '%s/%s_flx.nc' % (self.expdir, self.expname)
 
@@ -154,13 +152,13 @@ class Output(Param):
     def join(self):
         if self.nbproc > 1:
             filename = self.hisfile.split('his')[0]+'his'
-            join(filename)
+            self.hisfile = join(filename)
             if self.diag_fluxes:
                 filename = self.flxfile.split('flx')[0]+'flx'
-                join(filename)
-                
-            
-            
+                self.flxfile = join(filename)
+
+
+
 class NcfileIO(object):
     """Allow to create() and write() a Netcdf file of 'history' type,
     i.e. a set of model 2D snapshots. Variables were originally the
@@ -250,7 +248,8 @@ def join(filename):
     ''' Join history files without having to mpirun
 
     Useful when the run has been broken and one wants to join
-    things from an interactive session '''
+    things from an interactive session.
+    Return the name of the new, joined history file. '''
 
     template = filename+'_%03i.nc'
     hisfile_joined = filename+'.nc'
@@ -390,3 +389,5 @@ def join(filename):
         os.remove(ncfile)
 
     print('-'*50)
+
+    return hisfile_joined

--- a/core/plotting.py
+++ b/core/plotting.py
@@ -22,6 +22,14 @@ class Plotting(object):
                            'generate_mp4', 'myrank', 'modelname']
         param.copy(self, self.list_param)
 
+        if param.npx * param.npy > 1 and self.generate_mp4:
+            print(
+                'Warning: It is not possible to generate an mp4-file when '
+                'fluid2d runs on multiple cores.\n'
+                'The parameter generate_mp4 is automatically changed to False.'
+            )
+            self.generate_mp4 = False
+
         nh = self.nh
         nx = param.nx
         ny = param.ny

--- a/core/restart.py
+++ b/core/restart.py
@@ -78,16 +78,10 @@ class Restart(object):
         f2d.output.template = self.expdir +'/%s_%02i_his' % (
             self.expname, self.nextrestart)+'_%03i.nc'
         f2d.output.hisfile = f2d.output.template % (self.myrank)
-        f2d.output.hisfile_joined = self.expdir + '/%s_%02i_his.nc' % (
-            self.expname, self.nextrestart)
         if self.diag_fluxes:
             f2d.output.template = self.expdir +'/%s_%02i_flx' % (
                 self.expname, self.nextrestart)+'_%03i.nc'
             f2d.output.flxfile = f2d.output.template % (self.myrank)
-            f2d.output.flxfile_joined = self.expdir + '/%s_%02i_flx.nc' % (
-                self.expname, self.nextrestart)
-            
-            
 
         # split the integration in 'ninterrestart' intervals and
         # save a restart at the end of each


### PR DESCRIPTION
When fluid2d runs on multiple cores, the name of the his file displayed
at the end was wrong.  The filename that was printed after the
simulation finished was the name of one of the his-files which was
joined into one big his-file and then removed.  With this commit,
fluid2d prints the correct name of the his-file after the run even when
using multiple cores.  The same is true for the flux file.

Creating an mp4-file while fluid2d runs on multiple cores was possible
so far, however, it resulted in the creation of just one file which
shows only some part of the domain, not fully.  Therefore it was only
limited usefully.  Furthermore it led to a crash, since several
fluid2d-processes called "finalize" on the same file.  Also creating an
mp4-file, which is not really helpful wastes resouces.  Therefore, this
commit disables the possbility to generate mp4s when fluid2d runs on
multiple cores.  A warning is printed instead.

The member variables of Output hisfile_joined and flxfile_joined were
unused and are now removed.