### PR TITLE
Fix QG model

### DIFF
--- a/core/quasigeostrophic.py
+++ b/core/quasigeostrophic.py
@@ -114,8 +114,7 @@ class QG(object):
         if self.noslip:
             self.add_noslip(self.var.state)
 
-        # self.set_psi_from_pv()
-        
+        self.set_psi_from_pv()
         # 3/ diagnostic fields
         self.var.state[self.ipva] = self.var.state[self.ipv] - self.pvback
         self.var.state[self.ivor] = (self.var.state[self.ipva]


### PR DESCRIPTION
In the previous commit “make the Von Karman street working again” (e1b3c65), a line was commented that seems to be crucial for the QG model. This commenting is reverted here. The von-Karman experiment is not affected by this change.